### PR TITLE
fix var-dir handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+4.3.3 (unreleased)
+
+  - Fix operation when the var directory is stored in a non-default location.
+    [adaugherity]
+
 4.3.2
 
   - Fix bug that caused failure in buildout if clients were directly specified.

--- a/src/plone/recipe/unifiedinstaller/__init__.py
+++ b/src/plone/recipe/unifiedinstaller/__init__.py
@@ -18,6 +18,7 @@ class Recipe:
         self._location = buildout['buildout']['directory']
         self._bin_directory = buildout['buildout']['bin-directory']
         self._parts_directory = buildout['buildout']['parts-directory']
+        self._var_dir = buildout['buildout']['var-dir']
         self._shell_command = options.get('shell-command', '/bin/sh')
         self._sudo_command = options.get('sudo-command', 'SUDOXXX')
         self._start_command = options.get('start-command', 'plonectl start')
@@ -29,7 +30,7 @@ class Recipe:
 
         # options['scripts'] = ''  # suppress script generation.
 
-        file_storage = options.get('file-storage', os.path.join(self._location, 'var', 'filestorage', 'Data.fs'))
+        file_storage = options.get('file-storage', os.path.join(self._var_dir, 'filestorage', 'Data.fs'))
         file_storage = os.path.join(self._location, file_storage)
         self._fileStorage = file_storage
         self._fileStorageDir = os.path.dirname(file_storage)


### PR DESCRIPTION
The Plone Unified Installer sets `${buildout:var-dir}` to the value passed to the `--var=` option of **install.sh**, or to `${buildout:directory}/var` by default, and uses this variable in several buildout parts.

This recipe, and thus the `bin/plonectl` command, however, currently hardcode the filestorage location to `${buildout:directory}/var/filestorage`, and **plonectl** fails to run when it is stored elsewhere:
```
$ pwd
/opt/plone/plone51_dev
$ grep var-dir= buildout.cfg
var-dir=/var/opt/zope213
$ ls /var/opt/zope213/filestorage/
Data.fs  Data.fs.index  Data.fs.lock  Data.fs.tmp
$ sudo bin/plonectl
/opt/plone/plone51_dev/var/filestorage doesn't exist. Run bin/buildout to configure your installation.
```

Using the `var-dir` variable for the filestorage location instead of hardcoding it fixes this:
```
$ sudo bin/plonectl status
zeoserver: program running; pid=32227
client1: program running; pid=32237
client2: program running; pid=32262
```